### PR TITLE
Protobuf and gRPC examples to send large messages

### DIFF
--- a/minimal_example/streaming_rpc/aggregator.proto
+++ b/minimal_example/streaming_rpc/aggregator.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package aggregator;
+
+service Aggregator {
+  rpc GetTasks(GetTasksRequest) returns (stream GetTasksResponseChunk) {}
+}
+
+message MessageHeader {
+  string sender = 1;
+  string receiver = 2;
+}
+
+message GetTasksRequest {
+  MessageHeader header = 1;
+}
+
+message GetTasksResponseChunk {
+  bytes chunk = 1;
+}
+
+message GetTasksResponse {
+  MessageHeader header = 1;
+  int32 round_number = 2;
+  string function_name = 3;
+  bytes ee = 4;
+  int32 sleep_time = 5;
+  bool quit = 6;
+}

--- a/minimal_example/streaming_rpc/model_client.py
+++ b/minimal_example/streaming_rpc/model_client.py
@@ -1,0 +1,49 @@
+import grpc
+import pickle
+import aggregator_pb2
+import aggregator_pb2_grpc
+from model_utils import CustomClass
+
+def reassemble_chunks(chunk_stream):
+    """Reassemble chunks from a stream into a single byte array."""
+    npbytes = bytearray()
+    index = 0
+    for chunk in chunk_stream:
+        index = index + 1
+        npbytes.extend(chunk.chunk)
+    print(f"<reassemble_chunks>: received: {index} chunks, total size: {len(npbytes)/(1024*1024)} MB")
+    return bytes(npbytes)
+
+def get_tasks(stub):
+    # Create a request
+    header = aggregator_pb2.MessageHeader(sender="client", receiver="server")
+    request = aggregator_pb2.GetTasksRequest(header=header)
+
+    # Get the response stream
+    response_stream = stub.GetTasks(request)
+
+    # Reassemble the chunks
+    serialized_response = reassemble_chunks(response_stream)
+    response = aggregator_pb2.GetTasksResponse()
+    response.ParseFromString(serialized_response)
+
+    # Deserialize the large object
+    large_object = pickle.loads(response.ee)
+
+    # Use the deserialized object
+    large_object.print_array_size()
+    large_object.print_array_shape()
+
+    print(f"Round Number: {response.round_number}")
+    print(f"Function Name: {response.function_name}")
+    print(f"Sleep Time: {response.sleep_time}")
+    print(f"Quit: {response.quit}")
+
+
+def run():
+    with grpc.insecure_channel('localhost:50051') as channel:
+        stub = aggregator_pb2_grpc.AggregatorStub(channel)
+        get_tasks(stub)
+
+if __name__ == '__main__':
+    run()

--- a/minimal_example/streaming_rpc/model_server.py
+++ b/minimal_example/streaming_rpc/model_server.py
@@ -1,0 +1,43 @@
+import grpc
+from concurrent import futures
+import pickle
+import aggregator_pb2
+import aggregator_pb2_grpc
+from model_utils import CustomClass
+from openfl.protocols.utils import proto_to_datastream
+from openfl.transport.grpc.common import DEFAULT_CHANNEL_OPTIONS
+
+class AggregatorServicer(aggregator_pb2_grpc.AggregatorServicer):
+    def GetTasks(self, request, context):
+        # Create a large Python object
+        large_object = CustomClass(array_size = 2*1024*1024*1024)
+        serialized_large_object = pickle.dumps(large_object)
+
+        # Build the GetTasksResponse
+        response = aggregator_pb2.GetTasksResponse(
+            header=request.header,
+            round_number=1,
+            function_name="example_function",
+            ee=serialized_large_object,
+            sleep_time=10,
+            quit=False
+        )
+
+        # Split the response into chunks
+        chunk_size = 1024 * 1024  # 1 MB
+        serialized_response = response.SerializeToString()
+        for i in range(0, len(serialized_response), chunk_size):
+            chunk = serialized_response[i:i + chunk_size]
+            yield aggregator_pb2.GetTasksResponseChunk(chunk=chunk)
+
+def serve():
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10), options=DEFAULT_CHANNEL_OPTIONS)
+    aggregator_pb2_grpc.add_AggregatorServicer_to_server(AggregatorServicer(), server)
+    server.add_insecure_port('[::]:50051')
+    server.start()
+    print("Server started at [::]:50051")
+    server.wait_for_termination()
+
+if __name__ == '__main__':
+    serve()
+

--- a/minimal_example/streaming_rpc/model_utils.py
+++ b/minimal_example/streaming_rpc/model_utils.py
@@ -1,0 +1,10 @@
+import numpy as np
+class CustomClass:
+    def __init__(self, array_size):
+        self.array = np.zeros(array_size, dtype=np.int8)
+    
+    def print_array_size(self):
+        print(f"Array size: {self.array.nbytes/(1024*1024)} MB")
+    
+    def print_array_shape(self):
+        print(f"Array shape: {self.array.nbytes/(1024*1024)} MB")

--- a/minimal_example/streaming_rpc_large/aggregator.proto
+++ b/minimal_example/streaming_rpc_large/aggregator.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package aggregator;
+
+service Aggregator {
+  rpc GetTasks(GetTasksRequest) returns (stream GetTasksResponseChunk) {}
+}
+
+message MessageHeader {
+  string sender = 1;
+  string receiver = 2;
+}
+
+message GetTasksRequest {
+  MessageHeader header = 1;
+}
+
+message GetTasksResponse {
+  MessageHeader header = 1;
+  int32 round_number = 2;
+  string function_name = 3;
+  bytes ee = 4;
+  int32 sleep_time = 5;
+  bool quit = 6;
+}
+
+message GetTasksResponseChunk {
+  bytes chunk = 1;
+}

--- a/minimal_example/streaming_rpc_large/model_client.py
+++ b/minimal_example/streaming_rpc_large/model_client.py
@@ -1,0 +1,61 @@
+import grpc
+import pickle
+import aggregator_pb2
+import aggregator_pb2_grpc
+from model_utils import CustomClass
+
+def reassemble_chunks(chunk_stream):
+    """Reassemble chunks from a stream into a single byte array."""
+    npbytes = bytearray()
+    response_metadata = None
+
+    for chunk in chunk_stream:
+        if response_metadata is None:
+            response_metadata = aggregator_pb2.GetTasksResponse()
+            response_metadata.ParseFromString(chunk.chunk)
+        else:
+            npbytes.extend(chunk.chunk)
+    return response_metadata, bytes(npbytes)
+
+def reassemble_chunks(chunk_stream):
+    """Reassemble chunks from a stream into a single byte array."""
+    npbytes = bytearray()
+    response_metadata = None
+
+    for chunk in chunk_stream:
+        if response_metadata is None:
+            response_metadata = aggregator_pb2.GetTasksResponse()
+            response_metadata.ParseFromString(chunk.chunk)
+        else:
+            npbytes.extend(chunk.chunk)
+    
+    return response_metadata, bytes(npbytes)
+
+def get_tasks(stub):
+    # Create a request
+    header = aggregator_pb2.MessageHeader(sender="client", receiver="server")
+    request = aggregator_pb2.GetTasksRequest(header=header)
+
+    # Get the response stream
+    response_stream = stub.GetTasks(request)
+
+    # Reassemble the chunks
+    response_metadata, serialized_large_object = reassemble_chunks(response_stream)
+    large_object = pickle.loads(serialized_large_object)
+
+    # Use the deserialized object
+    large_object.print_array_size()
+    large_object.print_array_shape()
+
+    print(f"Round Number: {response_metadata.round_number}")
+    print(f"Function Name: {response_metadata.function_name}")
+    print(f"Sleep Time: {response_metadata.sleep_time}")
+    print(f"Quit: {response_metadata.quit}")
+
+def run():
+    with grpc.insecure_channel('localhost:50051') as channel:
+        stub = aggregator_pb2_grpc.AggregatorStub(channel)
+        get_tasks(stub)
+
+if __name__ == '__main__':
+    run()

--- a/minimal_example/streaming_rpc_large/model_server.py
+++ b/minimal_example/streaming_rpc_large/model_server.py
@@ -1,0 +1,50 @@
+import grpc
+from concurrent import futures
+import pickle
+import aggregator_pb2
+import aggregator_pb2_grpc
+import numpy as np
+from openfl.transport.grpc.common import DEFAULT_CHANNEL_OPTIONS
+from model_utils import CustomClass
+
+class AggregatorServicer(aggregator_pb2_grpc.AggregatorServicer):
+    def GetTasks(self, request, context):
+        # Create a large CustomClass object
+        large_object = CustomClass(10*1024*1024*1024)
+        serialized_large_object = pickle.dumps(large_object)
+
+        # Build the GetTasksResponse
+        response = aggregator_pb2.GetTasksResponse(
+            header=request.header,
+            round_number=1,
+            function_name="example_function",
+            ee=b'',  # Placeholder for the large object
+            sleep_time=10,
+            quit=False
+        )
+
+        # Send the GetTasksResponse metadata first
+        yield aggregator_pb2.GetTasksResponseChunk(chunk=response.SerializeToString())
+
+        # Split the serialized large object into chunks and stream them
+        chunk_size = 2* 1024 * 1024  # 1 MB
+        for i in range(0, len(serialized_large_object), chunk_size):
+            chunk = serialized_large_object[i:i + chunk_size]
+            yield aggregator_pb2.GetTasksResponseChunk(chunk=chunk)
+
+def serve():
+    server = grpc.server(
+        futures.ThreadPoolExecutor(max_workers=10),
+        options=[
+            ('grpc.max_send_message_length', 1024 * 1024 * 50),  # 50 MB
+            ('grpc.max_receive_message_length', 1024 * 1024 * 50)  # 50 MB
+        ]
+    )
+    aggregator_pb2_grpc.add_AggregatorServicer_to_server(AggregatorServicer(), server)
+    server.add_insecure_port('[::]:50051')
+    server.start()
+    print("Server started at [::]:50051")
+    server.wait_for_termination()
+
+if __name__ == '__main__':
+    serve()

--- a/minimal_example/streaming_rpc_large/model_utils.py
+++ b/minimal_example/streaming_rpc_large/model_utils.py
@@ -1,0 +1,10 @@
+import numpy as np
+class CustomClass:
+    def __init__(self, array_size):
+        self.array = np.zeros(array_size, dtype=np.int8)
+    
+    def print_array_size(self):
+        print(f"Array size: {self.array.nbytes/(1024*1024)} MB")
+    
+    def print_array_shape(self):
+        print(f"Array shape: {self.array.nbytes/(1024*1024)} MB")


### PR DESCRIPTION
**minimal_example/streaming_rpc**
- Example which uses streaming_rpc
- Limit: 2GB due to `protobuf.ParseFromString` limit [Proto limits](https://protobuf.dev/programming-guides/proto-limits/) and [Proto Encoding](https://protobuf.dev/programming-guides/encoding/)